### PR TITLE
Update fieldtypes.fr.yml

### DIFF
--- a/src/bundle/Resources/translations/fieldtypes.en.yml
+++ b/src/bundle/Resources/translations/fieldtypes.en.yml
@@ -1,2 +1,2 @@
-menuitem: { name: "Menu Item" }
+menu: { name: "Menu Item" }
 field_definition.menuitem.default_value: "Default value"

--- a/src/bundle/Resources/translations/fieldtypes.fr.yml
+++ b/src/bundle/Resources/translations/fieldtypes.fr.yml
@@ -1,2 +1,2 @@
-menuitem: { name: "Menu Item" }
+menu: { name: "Menu Item" }
 field_definition.menuitem.default_value: "Default value"


### PR DESCRIPTION
changing `menuitem.name` to `menu.name` as it is use in : https://github.com/Novactive/NovaeZMenuManagerBundle/blob/master/src/bundle/Resources/views/themes/standard/ezadminui/field/edit/menuitem.html.twig#L15

![Capture d’écran 2019-08-19 à 14 25 29](https://user-images.githubusercontent.com/1842696/63353083-7d6cbb80-c362-11e9-98bc-e6a5af34af9a.png)
